### PR TITLE
Fixes dialog closing unexpectedly

### DIFF
--- a/primitives/src/dialog.rs
+++ b/primitives/src/dialog.rs
@@ -4,8 +4,8 @@ use dioxus::document;
 use dioxus::prelude::*;
 
 use crate::{
-    use_animated_open, use_controlled, use_global_escape_listener, use_id_or, use_outside_dismiss,
-    use_unique_id, FOCUS_TRAP_JS,
+    use_animated_open, use_controlled, use_global_escape_listener, use_id_or, use_unique_id,
+    FOCUS_TRAP_JS,
 };
 
 /// Context for the [`DialogRoot`] component
@@ -141,6 +141,7 @@ pub fn DialogRoot(props: DialogRootProps) -> Element {
                 id,
                 aria_hidden: (!open()).then_some("true"),
                 "data-state": if open() { "open" } else { "closed" },
+                onclick: move |_| set_open.call(false),
                 ..props.attributes,
                 {props.children}
             }
@@ -228,7 +229,6 @@ pub fn DialogContent(props: DialogContentProps) -> Element {
     let gen_id = use_unique_id();
     let id = use_id_or(gen_id, props.id);
 
-    use_outside_dismiss(id, move || set_open.call(false));
     use_effect(move || {
         let is_modal = is_modal();
         if !is_modal {
@@ -261,6 +261,7 @@ pub fn DialogContent(props: DialogContentProps) -> Element {
             aria_labelledby: ctx.dialog_labelledby,
             aria_describedby: ctx.dialog_describedby,
             class: props.class.clone().unwrap_or_else(|| "dx-dialog".to_string()),
+            onclick: move |evt| evt.stop_propagation(),
             ..props.attributes,
             {props.children}
         }


### PR DESCRIPTION
In the newer versions of dioxus-primitives, dialogs would close when clicking on their internal content such as text and empty space. This PR aims to fix this by using the internal dioxus event implementation instead of javascript. Specifically I removed `use_outside_dismiss` in the `DialogContent` and replaced it with an onclick handler on the `DialogRoot` backdrop.

If this implementation doesn't cover all of `use_outside_dismiss`'s features I'll be happy to add them. 