### PR TITLE
prevent line breaking of sidebar-wrapper class element's data-node

### DIFF
--- a/preview/src/components/sidebar/component.rs
+++ b/preview/src/components/sidebar/component.rs
@@ -236,11 +236,7 @@ pub fn SidebarProvider(
     });
 
     let sidebar_style = format!(
-        r#"
-        --dx-sidebar-width: {SIDEBAR_WIDTH};
-        --dx-sidebar-width-mobile: {SIDEBAR_WIDTH_MOBILE};
-        --dx-sidebar-width-icon: {SIDEBAR_WIDTH_ICON}
-        "#
+        r#"--dx-sidebar-width: {SIDEBAR_WIDTH}; --dx-sidebar-width-mobile: {SIDEBAR_WIDTH_MOBILE}; --dx-sidebar-width-icon: {SIDEBAR_WIDTH_ICON}"#
     );
 
     let base = attributes!(div {


### PR DESCRIPTION
This is how the html looked like inside inspector, before fix
```html
<div class="sidebar-wrapper" data-slot="sidebar-wrapper" style="
        --sidebar-width: 16rem;
        --sidebar-width-mobile: 18rem;
        --sidebar-width-icon: 3rem
        " data-node-hydration="2">
```