### PR TITLE
fix: swallow canceled Animation.finished rejections in use_animated_open

### DIFF
--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -262,7 +262,7 @@ fn use_animated_open(
                     "const id = await dioxus.recv();
                     const element = document.getElementById(id);
                     if (element && element.getAnimations().length > 0) {
-                        Promise.all(element.getAnimations().map((animation) => animation.finished)).then(() => {
+                        Promise.all(element.getAnimations().map((animation) => animation.finished.catch(() => {}))).then(() => {
                             dioxus.send(true);
                         });
                     } else {


### PR DESCRIPTION
## Summary
- `use_animated_open` waits for in-flight animations/transitions on the closing element to finish via `Promise.all(element.getAnimations().map(a => a.finished)).then(...)`.
- If any of those animations is *canceled* rather than finishing naturally (e.g. the element is removed from the DOM before the transition completes), its `.finished` promise rejects with a `DOMException` (`AbortError: The user aborted a request.`).
- Since the `Promise.all(...)` chain has no `.catch()`, this becomes an unhandled promise rejection, logged in the browser console as `Uncaught (in promise) AbortError: The user aborted a request.`
- This reproduces with any consumer component (e.g. `DropdownMenu`) whose content has a plain CSS `transition` (not even a keyframe `animation` — CSS Transitions are also returned by `Element.getAnimations()`), when the item's `on_select` handler triggers a DOM change (e.g. navigation) that removes the element while its close transition is still running.

## Fix
Swallow the per-animation rejection with `.catch(() => {})` before `Promise.all` so a canceled animation resolves like a finished one instead of rejecting the aggregate promise.

Reported in #290, with a CDP-verified repro pinpointing the exact `animation.finished` access as the throw site.

## Test plan
- [x] `cargo fmt --check -p dioxus-primitives`
- Verified in a downstream app (Dioxus 0.7 fullstack) via Playwright + Chrome DevTools Protocol (`Runtime.exceptionThrown`) that the previously-reproducing "avatar dropdown → navigate" flow no longer throws after this change (built against this commit locally).
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://dioxus.staging.devinenterprise.com/review/DioxusLabs/dioxus-components/pull/291?analyze=true)

> 💡 [Connect your GitHub account](https://dioxus.staging.devinenterprise.com/settings/profile#linked-accounts) to enable automatic code reviews.

<a href="https://dioxus.staging.devinenterprise.com/review/DioxusLabs/dioxus-components/pull/291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->